### PR TITLE
Replace Github runner with FlyCI MacOS runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [flyci-macos-large-latest-m1]
+        os: [flyci-macos-large-latest-m2]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [windows-latest, flyci-macos-large-latest-m2]
+        os: [flyci-macos-large-latest-m1]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [windows-latest, macos-latest]
+        os: [windows-latest, flyci-macos-large-latest-m2]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
This runner replaces `macos-13` with `flyci-macos-large-latest-m2`.